### PR TITLE
ci: fix syntax in regen action

### DIFF
--- a/.github/workflows/regen-data.yml
+++ b/.github/workflows/regen-data.yml
@@ -1,7 +1,6 @@
 name: 'Regen Data'
 
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   regen:


### PR DESCRIPTION
Fixes the syntax in the regen action so that it can be triggered from the action view, once this is merged I'll trigger a build and 🤞🏻 it works