### PR TITLE
ci: dont verify commits and add specific message

### DIFF
--- a/.github/workflows/regen-data.yml
+++ b/.github/workflows/regen-data.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Commit changes
         id: committed
         uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'chore: update module list'
+          commit_options: '--no-verify'
 
       - name: Repository Dispatch
         if: steps.committed.outputs.changes_detected == 'true'


### PR DESCRIPTION
The [run](https://github.com/tidev/module-search-www/actions/runs/6841703369/job/18602361921) failed because of husky failing to run, realistically we don't need that in CI so just turn it off 