### PR TITLE
ci: dont install husky hooks when installing dependencies

### DIFF
--- a/.github/workflows/regen-data.yml
+++ b/.github/workflows/regen-data.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn
+        env:
+          HUSKY: 0
 
       - name: Generate data
         run: node scripts/generate.mjs


### PR DESCRIPTION
Take 2 at trying to not have husky run on the regen commit